### PR TITLE
Add two files for viewing default obsidian colors

### DIFF
--- a/default-obsidian-colors.md
+++ b/default-obsidian-colors.md
@@ -1,0 +1,78 @@
+
+# Default Obsidian Colors
+
+Add/Enable `test-default-obsidian-colors.css` as a Snippet in obsidian.
+The following two tables will show the default obsidian colors in the 
+foreground and in the background.
+
+## Dark Mode
+
+<table>
+<tr><td>background-primary: #202020</td><td class="test-theme-dark-background-primary">background-primary</td><td class="test-theme-dark-background-primary-bg">background-primary</td></tr>
+<tr><td>background-primary-alt: #1a1a1a</td><td class="test-theme-dark-background-primary-alt">background-primary-alt</td><td class="test-theme-dark-background-primary-alt-bg">background-primary-alt</td></tr>
+<tr><td>background-secondary: #161616</td><td class="test-theme-dark-background-secondary">background-secondary</td><td class="test-theme-dark-background-secondary-bg">background-secondary</td></tr>
+<tr><td>background-secondary-alt: #000000</td><td class="test-theme-dark-background-secondary-alt">background-secondary-alt</td><td class="test-theme-dark-background-secondary-alt-bg">background-secondary-alt</td></tr>
+<tr><td>background-modifier-border: #333</td><td class="test-theme-dark-background-modifier-border">background-modifier-border</td><td class="test-theme-dark-background-modifier-border-bg">background-modifier-border</td></tr>
+<tr><td>background-modifier-form-field: rgba(0, 0, 0, 0.3)</td><td class="test-theme-dark-background-modifier-form-field">background-modifier-form-field</td><td class="test-theme-dark-background-modifier-form-field-bg">background-modifier-form-field</td></tr>
+<tr><td>background-modifier-form-field-highlighted: rgba(0, 0, 0, 0.22)</td><td class="test-theme-dark-background-modifier-form-field-highlighted">background-modifier-form-field-highlighted</td><td class="test-theme-dark-background-modifier-form-field-highlighted-bg">background-modifier-form-field-highlighted</td></tr>
+<tr><td>background-modifier-box-shadow: rgba(0, 0, 0, 0.3)</td><td class="test-theme-dark-background-modifier-box-shadow">background-modifier-box-shadow</td><td class="test-theme-dark-background-modifier-box-shadow-bg">background-modifier-box-shadow</td></tr>
+<tr><td>background-modifier-success: #197300</td><td class="test-theme-dark-background-modifier-success">background-modifier-success</td><td class="test-theme-dark-background-modifier-success-bg">background-modifier-success</td></tr>
+<tr><td>background-modifier-error: #3d0000</td><td class="test-theme-dark-background-modifier-error">background-modifier-error</td><td class="test-theme-dark-background-modifier-error-bg">background-modifier-error</td></tr>
+<tr><td>background-modifier-error-hover: #470000</td><td class="test-theme-dark-background-modifier-error-hover">background-modifier-error-hover</td><td class="test-theme-dark-background-modifier-error-hover-bg">background-modifier-error-hover</td></tr>
+<tr><td>background-modifier-cover: rgba(0, 0, 0, 0.8)</td><td class="test-theme-dark-background-modifier-cover">background-modifier-cover</td><td class="test-theme-dark-background-modifier-cover-bg">background-modifier-cover</td></tr>
+<tr><td>text-accent: #7f6df2</td><td class="test-theme-dark-text-accent">text-accent</td><td class="test-theme-dark-text-accent-bg">text-accent</td></tr>
+<tr><td>text-accent-hover: #8875ff</td><td class="test-theme-dark-text-accent-hover">text-accent-hover</td><td class="test-theme-dark-text-accent-hover-bg">text-accent-hover</td></tr>
+<tr><td>text-normal: #dcddde</td><td class="test-theme-dark-text-normal">text-normal</td><td class="test-theme-dark-text-normal-bg">text-normal</td></tr>
+<tr><td>text-muted: #999</td><td class="test-theme-dark-text-muted">text-muted</td><td class="test-theme-dark-text-muted-bg">text-muted</td></tr>
+<tr><td>text-faint: #666</td><td class="test-theme-dark-text-faint">text-faint</td><td class="test-theme-dark-text-faint-bg">text-faint</td></tr>
+<tr><td>text-error: #ff3333</td><td class="test-theme-dark-text-error">text-error</td><td class="test-theme-dark-text-error-bg">text-error</td></tr>
+<tr><td>text-error-hover: #990000</td><td class="test-theme-dark-text-error-hover">text-error-hover</td><td class="test-theme-dark-text-error-hover-bg">text-error-hover</td></tr>
+<tr><td>text-highlight-bg: rgba(255, 255, 0, 0.4)</td><td class="test-theme-dark-text-highlight-bg">text-highlight-bg</td><td class="test-theme-dark-text-highlight-bg-bg">text-highlight-bg</td></tr>
+<tr><td>text-highlight-bg-active: rgba(255, 128, 0, 0.4)</td><td class="test-theme-dark-text-highlight-bg-active">text-highlight-bg-active</td><td class="test-theme-dark-text-highlight-bg-active-bg">text-highlight-bg-active</td></tr>
+<tr><td>text-selection: rgba(23, 48, 77, 0.99)</td><td class="test-theme-dark-text-selection">text-selection</td><td class="test-theme-dark-text-selection-bg">text-selection</td></tr>
+<tr><td>text-on-accent: #dcddde</td><td class="test-theme-dark-text-on-accent">text-on-accent</td><td class="test-theme-dark-text-on-accent-bg">text-on-accent</td></tr>
+<tr><td>interactive-normal: #2a2a2a</td><td class="test-theme-dark-interactive-normal">interactive-normal</td><td class="test-theme-dark-interactive-normal-bg">interactive-normal</td></tr>
+<tr><td>interactive-hover: #303030</td><td class="test-theme-dark-interactive-hover">interactive-hover</td><td class="test-theme-dark-interactive-hover-bg">interactive-hover</td></tr>
+<tr><td>interactive-accent: #483699</td><td class="test-theme-dark-interactive-accent">interactive-accent</td><td class="test-theme-dark-interactive-accent-bg">interactive-accent</td></tr>
+<tr><td>interactive-accent-hover: #4d3ca6</td><td class="test-theme-dark-interactive-accent-hover">interactive-accent-hover</td><td class="test-theme-dark-interactive-accent-hover-bg">interactive-accent-hover</td></tr>
+<tr><td>interactive-success: #197300</td><td class="test-theme-dark-interactive-success">interactive-success</td><td class="test-theme-dark-interactive-success-bg">interactive-success</td></tr>
+<tr><td>scrollbar-active-thumb-bg: rgba(255, 255, 255, 0.2)</td><td class="test-theme-dark-scrollbar-active-thumb-bg">scrollbar-active-thumb-bg</td><td class="test-theme-dark-scrollbar-active-thumb-bg-bg">scrollbar-active-thumb-bg</td></tr>
+<tr><td>scrollbar-bg: rgba(255, 255, 255, 0.05)</td><td class="test-theme-dark-scrollbar-bg">scrollbar-bg</td><td class="test-theme-dark-scrollbar-bg-bg">scrollbar-bg</td></tr>
+<tr><td>scrollbar-thumb-bg: rgba(255, 255, 255, 0.1)</td><td class="test-theme-dark-scrollbar-thumb-bg">scrollbar-thumb-bg</td><td class="test-theme-dark-scrollbar-thumb-bg-bg">scrollbar-thumb-bg</td></tr>
+</table>
+
+## Light Mode
+
+<table>
+<tr><td>background-primary: #ffffff</td><td class="test-theme-light-background-primary">background-primary</td><td class="test-theme-light-background-primary-bg">background-primary</td></tr>
+<tr><td>background-primary-alt: #f5f6f8</td><td class="test-theme-light-background-primary-alt">background-primary-alt</td><td class="test-theme-light-background-primary-alt-bg">background-primary-alt</td></tr>
+<tr><td>background-secondary: #f2f3f5</td><td class="test-theme-light-background-secondary">background-secondary</td><td class="test-theme-light-background-secondary-bg">background-secondary</td></tr>
+<tr><td>background-secondary-alt: #e3e5e8</td><td class="test-theme-light-background-secondary-alt">background-secondary-alt</td><td class="test-theme-light-background-secondary-alt-bg">background-secondary-alt</td></tr>
+<tr><td>background-modifier-border: #ddd</td><td class="test-theme-light-background-modifier-border">background-modifier-border</td><td class="test-theme-light-background-modifier-border-bg">background-modifier-border</td></tr>
+<tr><td>background-modifier-form-field: #fff</td><td class="test-theme-light-background-modifier-form-field">background-modifier-form-field</td><td class="test-theme-light-background-modifier-form-field-bg">background-modifier-form-field</td></tr>
+<tr><td>background-modifier-form-field-highlighted: #fff</td><td class="test-theme-light-background-modifier-form-field-highlighted">background-modifier-form-field-highlighted</td><td class="test-theme-light-background-modifier-form-field-highlighted-bg">background-modifier-form-field-highlighted</td></tr>
+<tr><td>background-modifier-box-shadow: rgba(0, 0, 0, 0.1)</td><td class="test-theme-light-background-modifier-box-shadow">background-modifier-box-shadow</td><td class="test-theme-light-background-modifier-box-shadow-bg">background-modifier-box-shadow</td></tr>
+<tr><td>background-modifier-success: #A4E7C3</td><td class="test-theme-light-background-modifier-success">background-modifier-success</td><td class="test-theme-light-background-modifier-success-bg">background-modifier-success</td></tr>
+<tr><td>background-modifier-error: #990000</td><td class="test-theme-light-background-modifier-error">background-modifier-error</td><td class="test-theme-light-background-modifier-error-bg">background-modifier-error</td></tr>
+<tr><td>background-modifier-error-hover: #bb0000</td><td class="test-theme-light-background-modifier-error-hover">background-modifier-error-hover</td><td class="test-theme-light-background-modifier-error-hover-bg">background-modifier-error-hover</td></tr>
+<tr><td>background-modifier-cover: rgba(0, 0, 0, 0.8)</td><td class="test-theme-light-background-modifier-cover">background-modifier-cover</td><td class="test-theme-light-background-modifier-cover-bg">background-modifier-cover</td></tr>
+<tr><td>text-accent: #705dcf</td><td class="test-theme-light-text-accent">text-accent</td><td class="test-theme-light-text-accent-bg">text-accent</td></tr>
+<tr><td>text-accent-hover: #7a6ae6</td><td class="test-theme-light-text-accent-hover">text-accent-hover</td><td class="test-theme-light-text-accent-hover-bg">text-accent-hover</td></tr>
+<tr><td>text-normal: #2e3338</td><td class="test-theme-light-text-normal">text-normal</td><td class="test-theme-light-text-normal-bg">text-normal</td></tr>
+<tr><td>text-muted: #888888</td><td class="test-theme-light-text-muted">text-muted</td><td class="test-theme-light-text-muted-bg">text-muted</td></tr>
+<tr><td>text-faint: #999999</td><td class="test-theme-light-text-faint">text-faint</td><td class="test-theme-light-text-faint-bg">text-faint</td></tr>
+<tr><td>text-error: #800000</td><td class="test-theme-light-text-error">text-error</td><td class="test-theme-light-text-error-bg">text-error</td></tr>
+<tr><td>text-error-hover: #990000</td><td class="test-theme-light-text-error-hover">text-error-hover</td><td class="test-theme-light-text-error-hover-bg">text-error-hover</td></tr>
+<tr><td>text-highlight-bg: rgba(255, 255, 0, 0.4)</td><td class="test-theme-light-text-highlight-bg">text-highlight-bg</td><td class="test-theme-light-text-highlight-bg-bg">text-highlight-bg</td></tr>
+<tr><td>text-highlight-bg-active: rgba(255, 128, 0, 0.4)</td><td class="test-theme-light-text-highlight-bg-active">text-highlight-bg-active</td><td class="test-theme-light-text-highlight-bg-active-bg">text-highlight-bg-active</td></tr>
+<tr><td>text-selection: rgba(204, 230, 255, 0.99)</td><td class="test-theme-light-text-selection">text-selection</td><td class="test-theme-light-text-selection-bg">text-selection</td></tr>
+<tr><td>text-on-accent: #f2f2f2</td><td class="test-theme-light-text-on-accent">text-on-accent</td><td class="test-theme-light-text-on-accent-bg">text-on-accent</td></tr>
+<tr><td>interactive-normal: #f2f3f5</td><td class="test-theme-light-interactive-normal">interactive-normal</td><td class="test-theme-light-interactive-normal-bg">interactive-normal</td></tr>
+<tr><td>interactive-hover: #e9e9e9</td><td class="test-theme-light-interactive-hover">interactive-hover</td><td class="test-theme-light-interactive-hover-bg">interactive-hover</td></tr>
+<tr><td>interactive-accent: #7b6cd9</td><td class="test-theme-light-interactive-accent">interactive-accent</td><td class="test-theme-light-interactive-accent-bg">interactive-accent</td></tr>
+<tr><td>interactive-accent-hover: #8273e6</td><td class="test-theme-light-interactive-accent-hover">interactive-accent-hover</td><td class="test-theme-light-interactive-accent-hover-bg">interactive-accent-hover</td></tr>
+<tr><td>interactive-success: #197300</td><td class="test-theme-light-interactive-success">interactive-success</td><td class="test-theme-light-interactive-success-bg">interactive-success</td></tr>
+<tr><td>scrollbar-active-thumb-bg: rgba(0, 0, 0, 0.2)</td><td class="test-theme-light-scrollbar-active-thumb-bg">scrollbar-active-thumb-bg</td><td class="test-theme-light-scrollbar-active-thumb-bg-bg">scrollbar-active-thumb-bg</td></tr>
+<tr><td>scrollbar-bg: rgba(0, 0, 0, 0.05)</td><td class="test-theme-light-scrollbar-bg">scrollbar-bg</td><td class="test-theme-light-scrollbar-bg-bg">scrollbar-bg</td></tr>
+<tr><td>scrollbar-thumb-bg: rgba(0, 0, 0, 0.1)</td><td class="test-theme-light-scrollbar-thumb-bg">scrollbar-thumb-bg</td><td class="test-theme-light-scrollbar-thumb-bg-bg">scrollbar-thumb-bg</td></tr>
+</table>

--- a/test-default-obsidian-colors.css
+++ b/test-default-obsidian-colors.css
@@ -1,0 +1,373 @@
+
+.test-theme-dark-background-primary {
+  color: #202020;
+}
+.test-theme-dark-background-primary-bg {
+  background-color: #202020;
+}
+.test-theme-dark-background-primary-alt {
+  color: #1a1a1a;
+}
+.test-theme-dark-background-primary-alt-bg {
+  background-color: #1a1a1a;
+}
+.test-theme-dark-background-secondary {
+  color: #161616;
+}
+.test-theme-dark-background-secondary-bg {
+  background-color: #161616;
+}
+.test-theme-dark-background-secondary-alt {
+  color: #000000;
+}
+.test-theme-dark-background-secondary-alt-bg {
+  background-color: #000000;
+}
+.test-theme-dark-background-modifier-border {
+  color: #333;
+}
+.test-theme-dark-background-modifier-border-bg {
+  background-color: #333;
+}
+.test-theme-dark-background-modifier-form-field {
+  color: rgba(0, 0, 0, 0.3);
+}
+.test-theme-dark-background-modifier-form-field-bg {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+.test-theme-dark-background-modifier-form-field-highlighted {
+  color: rgba(0, 0, 0, 0.22);
+}
+.test-theme-dark-background-modifier-form-field-highlighted-bg {
+  background-color: rgba(0, 0, 0, 0.22);
+}
+.test-theme-dark-background-modifier-box-shadow {
+  color: rgba(0, 0, 0, 0.3);
+}
+.test-theme-dark-background-modifier-box-shadow-bg {
+  background-color: rgba(0, 0, 0, 0.3);
+}
+.test-theme-dark-background-modifier-success {
+  color: #197300;
+}
+.test-theme-dark-background-modifier-success-bg {
+  background-color: #197300;
+}
+.test-theme-dark-background-modifier-error {
+  color: #3d0000;
+}
+.test-theme-dark-background-modifier-error-bg {
+  background-color: #3d0000;
+}
+.test-theme-dark-background-modifier-error-hover {
+  color: #470000;
+}
+.test-theme-dark-background-modifier-error-hover-bg {
+  background-color: #470000;
+}
+.test-theme-dark-background-modifier-cover {
+  color: rgba(0, 0, 0, 0.8);
+}
+.test-theme-dark-background-modifier-cover-bg {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+.test-theme-dark-text-accent {
+  color: #7f6df2;
+}
+.test-theme-dark-text-accent-bg {
+  background-color: #7f6df2;
+}
+.test-theme-dark-text-accent-hover {
+  color: #8875ff;
+}
+.test-theme-dark-text-accent-hover-bg {
+  background-color: #8875ff;
+}
+.test-theme-dark-text-normal {
+  color: #dcddde;
+}
+.test-theme-dark-text-normal-bg {
+  background-color: #dcddde;
+}
+.test-theme-dark-text-muted {
+  color: #999;
+}
+.test-theme-dark-text-muted-bg {
+  background-color: #999;
+}
+.test-theme-dark-text-faint {
+  color: #666;
+}
+.test-theme-dark-text-faint-bg {
+  background-color: #666;
+}
+.test-theme-dark-text-error {
+  color: #ff3333;
+}
+.test-theme-dark-text-error-bg {
+  background-color: #ff3333;
+}
+.test-theme-dark-text-error-hover {
+  color: #990000;
+}
+.test-theme-dark-text-error-hover-bg {
+  background-color: #990000;
+}
+.test-theme-dark-text-highlight-bg {
+  color: rgba(255, 255, 0, 0.4);
+}
+.test-theme-dark-text-highlight-bg-bg {
+  background-color: rgba(255, 255, 0, 0.4);
+}
+.test-theme-dark-text-highlight-bg-active {
+  color: rgba(255, 128, 0, 0.4);
+}
+.test-theme-dark-text-highlight-bg-active-bg {
+  background-color: rgba(255, 128, 0, 0.4);
+}
+.test-theme-dark-text-selection {
+  color: rgba(23, 48, 77, 0.99);
+}
+.test-theme-dark-text-selection-bg {
+  background-color: rgba(23, 48, 77, 0.99);
+}
+.test-theme-dark-text-on-accent {
+  color: #dcddde;
+}
+.test-theme-dark-text-on-accent-bg {
+  background-color: #dcddde;
+}
+.test-theme-dark-interactive-normal {
+  color: #2a2a2a;
+}
+.test-theme-dark-interactive-normal-bg {
+  background-color: #2a2a2a;
+}
+.test-theme-dark-interactive-hover {
+  color: #303030;
+}
+.test-theme-dark-interactive-hover-bg {
+  background-color: #303030;
+}
+.test-theme-dark-interactive-accent {
+  color: #483699;
+}
+.test-theme-dark-interactive-accent-bg {
+  background-color: #483699;
+}
+.test-theme-dark-interactive-accent-hover {
+  color: #4d3ca6;
+}
+.test-theme-dark-interactive-accent-hover-bg {
+  background-color: #4d3ca6;
+}
+.test-theme-dark-interactive-success {
+  color: #197300;
+}
+.test-theme-dark-interactive-success-bg {
+  background-color: #197300;
+}
+.test-theme-dark-scrollbar-active-thumb-bg {
+  color: rgba(255, 255, 255, 0.2);
+}
+.test-theme-dark-scrollbar-active-thumb-bg-bg {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+.test-theme-dark-scrollbar-bg {
+  color: rgba(255, 255, 255, 0.05);
+}
+.test-theme-dark-scrollbar-bg-bg {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+.test-theme-dark-scrollbar-thumb-bg {
+  color: rgba(255, 255, 255, 0.1);
+}
+.test-theme-dark-scrollbar-thumb-bg-bg {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+.test-theme-light-background-primary {
+  color: #ffffff;
+}
+.test-theme-light-background-primary-bg {
+  background-color: #ffffff;
+}
+.test-theme-light-background-primary-alt {
+  color: #f5f6f8;
+}
+.test-theme-light-background-primary-alt-bg {
+  background-color: #f5f6f8;
+}
+.test-theme-light-background-secondary {
+  color: #f2f3f5;
+}
+.test-theme-light-background-secondary-bg {
+  background-color: #f2f3f5;
+}
+.test-theme-light-background-secondary-alt {
+  color: #e3e5e8;
+}
+.test-theme-light-background-secondary-alt-bg {
+  background-color: #e3e5e8;
+}
+.test-theme-light-background-modifier-border {
+  color: #ddd;
+}
+.test-theme-light-background-modifier-border-bg {
+  background-color: #ddd;
+}
+.test-theme-light-background-modifier-form-field {
+  color: #fff;
+}
+.test-theme-light-background-modifier-form-field-bg {
+  background-color: #fff;
+}
+.test-theme-light-background-modifier-form-field-highlighted {
+  color: #fff;
+}
+.test-theme-light-background-modifier-form-field-highlighted-bg {
+  background-color: #fff;
+}
+.test-theme-light-background-modifier-box-shadow {
+  color: rgba(0, 0, 0, 0.1);
+}
+.test-theme-light-background-modifier-box-shadow-bg {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+.test-theme-light-background-modifier-success {
+  color: #A4E7C3;
+}
+.test-theme-light-background-modifier-success-bg {
+  background-color: #A4E7C3;
+}
+.test-theme-light-background-modifier-error {
+  color: #990000;
+}
+.test-theme-light-background-modifier-error-bg {
+  background-color: #990000;
+}
+.test-theme-light-background-modifier-error-hover {
+  color: #bb0000;
+}
+.test-theme-light-background-modifier-error-hover-bg {
+  background-color: #bb0000;
+}
+.test-theme-light-background-modifier-cover {
+  color: rgba(0, 0, 0, 0.8);
+}
+.test-theme-light-background-modifier-cover-bg {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+.test-theme-light-text-accent {
+  color: #705dcf;
+}
+.test-theme-light-text-accent-bg {
+  background-color: #705dcf;
+}
+.test-theme-light-text-accent-hover {
+  color: #7a6ae6;
+}
+.test-theme-light-text-accent-hover-bg {
+  background-color: #7a6ae6;
+}
+.test-theme-light-text-normal {
+  color: #2e3338;
+}
+.test-theme-light-text-normal-bg {
+  background-color: #2e3338;
+}
+.test-theme-light-text-muted {
+  color: #888888;
+}
+.test-theme-light-text-muted-bg {
+  background-color: #888888;
+}
+.test-theme-light-text-faint {
+  color: #999999;
+}
+.test-theme-light-text-faint-bg {
+  background-color: #999999;
+}
+.test-theme-light-text-error {
+  color: #800000;
+}
+.test-theme-light-text-error-bg {
+  background-color: #800000;
+}
+.test-theme-light-text-error-hover {
+  color: #990000;
+}
+.test-theme-light-text-error-hover-bg {
+  background-color: #990000;
+}
+.test-theme-light-text-highlight-bg {
+  color: rgba(255, 255, 0, 0.4);
+}
+.test-theme-light-text-highlight-bg-bg {
+  background-color: rgba(255, 255, 0, 0.4);
+}
+.test-theme-light-text-highlight-bg-active {
+  color: rgba(255, 128, 0, 0.4);
+}
+.test-theme-light-text-highlight-bg-active-bg {
+  background-color: rgba(255, 128, 0, 0.4);
+}
+.test-theme-light-text-selection {
+  color: rgba(204, 230, 255, 0.99);
+}
+.test-theme-light-text-selection-bg {
+  background-color: rgba(204, 230, 255, 0.99);
+}
+.test-theme-light-text-on-accent {
+  color: #f2f2f2;
+}
+.test-theme-light-text-on-accent-bg {
+  background-color: #f2f2f2;
+}
+.test-theme-light-interactive-normal {
+  color: #f2f3f5;
+}
+.test-theme-light-interactive-normal-bg {
+  background-color: #f2f3f5;
+}
+.test-theme-light-interactive-hover {
+  color: #e9e9e9;
+}
+.test-theme-light-interactive-hover-bg {
+  background-color: #e9e9e9;
+}
+.test-theme-light-interactive-accent {
+  color: #7b6cd9;
+}
+.test-theme-light-interactive-accent-bg {
+  background-color: #7b6cd9;
+}
+.test-theme-light-interactive-accent-hover {
+  color: #8273e6;
+}
+.test-theme-light-interactive-accent-hover-bg {
+  background-color: #8273e6;
+}
+.test-theme-light-interactive-success {
+  color: #197300;
+}
+.test-theme-light-interactive-success-bg {
+  background-color: #197300;
+}
+.test-theme-light-scrollbar-active-thumb-bg {
+  color: rgba(0, 0, 0, 0.2);
+}
+.test-theme-light-scrollbar-active-thumb-bg-bg {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+.test-theme-light-scrollbar-bg {
+  color: rgba(0, 0, 0, 0.05);
+}
+.test-theme-light-scrollbar-bg-bg {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+.test-theme-light-scrollbar-thumb-bg {
+  color: rgba(0, 0, 0, 0.1);
+}
+.test-theme-light-scrollbar-thumb-bg-bg {
+  background-color: rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
These files show the default color scheme as a table: 
<img width="653" alt="image" src="https://user-images.githubusercontent.com/808713/134435214-8cd7474a-15b2-4483-bf5e-3f42266fe2ec.png">

Some tweaks should be made, e.g. the highlight color should have the right styles added to lighten/darken highlights.. 