### PR TITLE
Fix extra "" on empty variable text elements

### DIFF
--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -190,7 +190,12 @@ function getCSSVariables(
                 ? value.toString()
                 : format_text.default.toString();
         if (format_text.quotes) {
-          text = `'${text}'`;
+          if (text !== `""`) {
+            text = `'${text}'`;
+          }
+          else {
+            text = ``;
+          }
         }
         vars.push({
           key: setting.id,

--- a/src/settingHandlers.ts
+++ b/src/settingHandlers.ts
@@ -387,7 +387,7 @@ export function createVariableText(opts: {
     .setName(getTitle(config))
     .setDesc(createDescription(getDescription(config), config.default))
     .addText((text) => {
-      const value = settingsManager.getSetting(sectionId, config.id);
+      let value = settingsManager.getSetting(sectionId, config.id);
       const onChange = debounce(
         (value: string) => {
           settingsManager.setSetting(sectionId, config.id, sanitizeText(value));
@@ -396,6 +396,9 @@ export function createVariableText(opts: {
         true
       );
 
+      if (config.quotes && value === `""`) {
+          value = ``;
+      }
       text
         .setValue(value ? value.toString() : config.default)
         .onChange(onChange);


### PR DESCRIPTION
This fixes problems with variable text, especially when using the quotes functionality. It might also be a bug when not using the quotes. 

Repro:
- Set default to ''  (empty string)
- Type some value in style settings
- Remove the value
- The content of the value is now the string `""` instead of the empty string
