### PR TITLE
fix: unload pickr instances on settings close

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@simonwep/pickr": "^1.8.2",
+    "@simonwep/pickr": "https://github.com/nothingislost/pickr/archive/a17739f7aa1871b44da778cbb79ae76dae77d839.tar.gz",
     "@types/chroma-js": "^2.1.3",
     "@types/js-yaml": "^4.0.3",
     "chroma-js": "^2.1.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,7 +197,10 @@ class SettingsMarkup {
   }
 
   cleanup() {
-    this.cleanupFns.forEach((fn) => fn && fn());
+    Array.from(this.cleanupFns).forEach((fn) => {
+      fn && fn();
+      this.cleanupFns.remove(fn);
+    });
   }
 
   setSettings(settings: ParsedCSSSettings[], errorList: ErrorList) {
@@ -343,6 +346,10 @@ class CSSSettingsTab extends PluginSettingTab {
 
   display(): void {
     this.settingsMarkup.display();
+  }
+
+  hide(): void {
+    this.settingsMarkup.cleanup();
   }
 }
 


### PR DESCRIPTION
- Switch to a fork of Pickr which tracks and cancels requestAnimationFrame requests properly
- Add logic to SettingsTab.hide() which unloads all Pickr instances