### PR TITLE
Selective setting rendering and seach function

### DIFF
--- a/src/SettingHandlers.ts
+++ b/src/SettingHandlers.ts
@@ -176,15 +176,11 @@ export function buildSettingComponentTree(opts: {
 
 	const root: HeadingSettingComponent = new HeadingSettingComponent(sectionId, sectionName, settings[0], settingsManager, isView);
 
-	console.log(settings);
-
 	let currentHeading: HeadingSettingComponent = root;
 
 	for (let setting of settings.splice(1)) {
 		if (setting.type === "heading") {
 			const newHeading: Heading = setting as Heading;
-
-			// console.log(newHeading);
 
 			if (newHeading.level < currentHeading.setting.level) {
 				while (newHeading.level < currentHeading.setting.level) {
@@ -202,7 +198,6 @@ export function buildSettingComponentTree(opts: {
 			currentHeading.addChild(setting);
 		}
 	}
-
 
 	return root;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,8 +63,6 @@ export default class CSSSettingsPlugin extends Plugin {
 		const dark = getComputedStyle(this.darkEl).getPropertyValue(`--${id}`);
 		const current = getComputedStyle(document.body).getPropertyValue(`--${id}`);
 
-		console.log(id, light, dark, current);
-
 		return {light, dark, current};
 	}
 


### PR DESCRIPTION
What id did:
- declutter some of the big files by extracting classes out into their own files
- rework the setting rendering
- settings now get parsed into a recursive structure
- search bar that allows filtering of the settings

What is still missing from this PR:
- ~~integration with javalents settings search plugin~~
- code comments

What no longer works:
- to get the color picker to be performant I had to hide it with `display: none` when not active. This breaks the fade in and out animation

What changed in terms of layout (important for theme devs)
- all root-level setting sections/headings are now contained in one div to separate them from the header
- the heading bar now has a search bar
- I am considering replacing the obsidian setting component that is used as a header with a simple flexbox div