### PR TITLE
Fix plugin-breaking bug by validating "variable-number" input before saving it

### DIFF
--- a/src/settingsView/SettingComponents/VariableNumberSettingComponent.ts
+++ b/src/settingsView/SettingComponents/VariableNumberSettingComponent.ts
@@ -31,14 +31,27 @@ export class VariableNumberSettingComponent extends AbstractSettingComponent {
 				this.sectionId,
 				this.setting.id
 			);
+
 			const onChange = debounce(
 				(value: string) => {
-					const isFloat = /\./.test(value);
-					this.settingsManager.setSetting(
-						this.sectionId,
-						this.setting.id,
-						isFloat ? parseFloat(value) : parseInt(value, 10)
-					);
+					const trimmedValue = value.trim(); // remove white space
+
+					const numericValue = parseFloat(trimmedValue); // Use parsefoat to handle integers and decimals
+
+					// CRUCIAL PART: Only save numbers by validating input before saving. Without this, users are able to input
+					// and save non-numeric values for CSS variables which only accept numbers as values. 
+					// This causes the associated settings to permanently break, and is irreversible, except for resetting all settings!
+					if (!isNaN(numericValue) && isFinite(numericValue)) {
+						this.settingsManager.setSetting(
+							this.sectionId,
+							this.setting.id,
+							numericValue
+						);
+					} else {
+						console.warn(`Style Settings: Invalid number input ignored for ${this.setting.id}: ${value}`);
+						const lastValidValue = this.settingsManager.getSetting(this.sectionId, this.setting.id);
+						text.setValue(lastValidValue !== undefined ? lastValidValue.toString() : this.setting.default.toString());
+					}
 				},
 				250,
 				true
@@ -47,6 +60,7 @@ export class VariableNumberSettingComponent extends AbstractSettingComponent {
 			text.setValue(
 				value !== undefined ? value.toString() : this.setting.default.toString()
 			);
+
 			text.onChange(onChange);
 
 			this.textComponent = text;
@@ -67,4 +81,6 @@ export class VariableNumberSettingComponent extends AbstractSettingComponent {
 	destroy(): void {
 		this.settingEl?.settingEl.remove();
 	}
+
+
 }


### PR DESCRIPTION
**Summary**
This PR adds input validation before saving values in `variable-number` type input fields, fixing a critical bug that breaks the plugin, with the only remedy being a complete reinstall of the StyleSettings plugin.

**Explanation**
The current code allows users to enter and save non-numerical values into the `variable-number` setting field. When this happens, a `NaN` value is saved to the CSS variable (due to `isFloat ? parseFloat(value) : parseInt(value, 10)`), which then turns into `null`. This is incredibly problematic, as once this happens the user loses the ability to edit this CSS variable, as StyleSettings does not display settings for that variable and any similar variables anymore, as it does not think it's a valid setting at that point.

Reproduction example:

1) In a new vault, install the Border theme (it works with any theme though), and StyleSettings.

2) In Style Settings options go to Editor->Headings->Level 1 Headings, and enter any non-numerical value into the `H1 font weight` setting. Such as `asd`, `a600`, `hfsdaf`, or similar.

![25-04-16_d9jVqNfp00](https://github.com/user-attachments/assets/f0e55bcb-27da-45c2-a6c2-61b81a8b6bf6)

3) Restart Obsidian

4) Observe that the setting you just changed is no longer functional. You can type, but it doesn't save anything entered into it anymore, as it's broken. Also, related variable settings are completely gone either.

![25-04-16_OYYmlyHPVg](https://github.com/user-attachments/assets/87ca001a-edbe-421c-bef2-2f3505a8267f)

In this example, the following StyleSetting is saved:

```
{
  "Editor@@h1-weight": null
}
```

And since this setting makes the h1-weight input field non-functional, along with all related input fields, the plugin is irreversibly broken and can only be fixed with a full reinstall.

@mgmeyers