### PR TITLE
fix: preserve color picker value on expand/collapse

### DIFF
--- a/src/settingsView/SettingComponents/VariableColorSettingComponent.ts
+++ b/src/settingsView/SettingComponents/VariableColorSettingComponent.ts
@@ -65,7 +65,7 @@ export class VariableColorSettingComponent extends AbstractSettingComponent {
 		// fix, so that the color is correctly shown before the color picker has been opened
 		const defaultColor =
 			value !== undefined ? (value as string) : this.setting.default;
-		this.containerEl.style.setProperty('--pcr-color', defaultColor);
+		this.settingEl.controlEl.style.setProperty('--pcr-color', defaultColor);
 
 		const pickr = (this.pickr = Pickr.create(
 			getPickrSettings({


### PR DESCRIPTION
The color picker was visually resetting when toggling settings groups because the '--pcr-color' CSS variable was applied to the generic containerEl.

Scoped the variable directly to settingEl.controlEl to ensure the current color persists across DOM remounts.

<img width="770" height="718" alt="image" src="https://github.com/user-attachments/assets/ecd48d64-0db2-44e9-a748-33ae51e3e9d4" />