### PR TITLE
fix: color swatch previews all show the last color in a group

### DIFF
--- a/src/settingsView/SettingComponents/VariableColorSettingComponent.ts
+++ b/src/settingsView/SettingComponents/VariableColorSettingComponent.ts
@@ -62,10 +62,9 @@ export class VariableColorSettingComponent extends AbstractSettingComponent {
 			createDescription(description, this.setting.default)
 		);
 
-		// fix, so that the color is correctly shown before the color picker has been opened
 		const defaultColor =
 			value !== undefined ? (value as string) : this.setting.default;
-		this.containerEl.style.setProperty('--pcr-color', defaultColor);
+		this.settingEl.controlEl.style.setProperty('--pcr-color', defaultColor);
 
 		const pickr = (this.pickr = Pickr.create(
 			getPickrSettings({


### PR DESCRIPTION
**fixes #122 & fixes #168**

when a heading contains multiple `variable-color` settings every color swatch
shows the last rows color until each picker is opened. the saved values are
correct but the closed state preview is wrong.

pickr renders the swatch from the inheriting `--pcr-color` custom property.
`VariableColorSettingComponent` was setting it on `this.containerEl`, which is the
`.style-settings-container` shared by all settings under one heading, so each
color row overwrote the previous one and the last row won for the entire group.

this pr sets `--pcr-color` on the rows own control element instead, matching what
`VariableThemedColorSettingComponent` already does on its per row wrapper.