### PR TITLE
fix: dont drop sections that start with level-0 heading

### DIFF
--- a/src/settingsView/SettingComponents/HeadingSettingComponent.ts
+++ b/src/settingsView/SettingComponents/HeadingSettingComponent.ts
@@ -164,9 +164,15 @@ export function buildSettingComponentTree(opts: {
 					) as HeadingSettingComponent;
 				}
 			} else if (newHeading.level === currentHeading.setting.level) {
-				currentHeading = currentHeading.parent.addSettingChild(
-					newHeading
-				) as HeadingSettingComponent;
+				if (currentHeading.setting.id === root.setting.id) {
+					currentHeading = currentHeading.addSettingChild(
+						newHeading
+					) as HeadingSettingComponent;
+				} else {
+					currentHeading = currentHeading.parent.addSettingChild(
+						newHeading
+					) as HeadingSettingComponent;
+				}
 			} else {
 				currentHeading = currentHeading.addSettingChild(
 					newHeading


### PR DESCRIPTION
**fixes #218**

a section whose first setting is a `heading` with `level: 0` never renders. the entire section silently disappears with no ui error.

`buildSettingComponentTree` adds the section name as level-0 root heading whose `.parent` is the container element. when a following heading has the same level as the current heading, it attaches to `currentHeading.parent`. at the root, `parent` is the container `HTMLElement`, which has no `addSettingChild`, so it throws and`SettingsMarkup.generate` catches the error and drops the section.

this pr adds the same guard the level-down branch already uses -> when the current heading is the root, attach the new heading to the root itself instead of to its non-component parent. non-root headings are unaffected.